### PR TITLE
Check NFTStorefront is the official one

### DIFF
--- a/contracts/Marketplace.cdc
+++ b/contracts/Marketplace.cdc
@@ -16,6 +16,9 @@ pub contract Marketplace {
         pub let timestamp: UFix64
 
         init(storefrontPublicCapability: Capability<&{NFTStorefront.StorefrontPublic}>, listingID: UInt64) {
+            // Upgrade contract: check NFTStorefront is the official one.
+            storefrontPublicCapability as! Capability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>
+
             self.storefrontPublicCapability = storefrontPublicCapability
             self.listingID = listingID
             let storefrontPublic = storefrontPublicCapability.borrow() ?? panic("Could not borrow public storefront from capability")


### PR DESCRIPTION
the bug mentioned in #1.

We don't change the type of storefrontPublicCapability of `Item`. Just check NFTStorefront is the official one so that we can migrate it to the new contract.